### PR TITLE
Added a 0.1.x branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
         "psr-4": {
             "League\\Tactician\\": "src"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1-dev"
+        }
     }
 }


### PR DESCRIPTION
This means people can require the using the version constraint `"0.1.*"`.