### PR TITLE
Rename HandlerMiddleware to CommandHandler

### DIFF
--- a/examples/1-beginner-standard-usage.php
+++ b/examples/1-beginner-standard-usage.php
@@ -27,7 +27,7 @@ $locator->addHandler(new RegisterUserHandler(), RegisterUserCommand::class);
 
 // Middleware is Tactician's plugin system. Even finding the handler and
 // executing it is a plugin that we're configuring here.
-$handlerMiddleware = new League\Tactician\Handler\HandlerMiddleware(
+$handlerMiddleware = new League\Tactician\Handler\CommandHandlerMiddleware(
     $locator,
     new HandleClassNameInflector()
 );

--- a/examples/2-intermediate-create-middleware.php
+++ b/examples/2-intermediate-create-middleware.php
@@ -59,7 +59,7 @@ class LoggingMiddleware implements Middleware
 //       incoming commands, you're free to do so. Just think carefully!
 
 // Now that we have a working Middleware object, we give it to our CommandBus
-// as a list of middleware. We'll also pass in the HandlerMiddleware we demoed
+// as a list of middleware. We'll also pass in the CommandHandlerMiddleware we demoed
 // in the previous example, otherwise our commands won't be executed!
 $commandBus = new StandardCommandBus(
     [

--- a/examples/3-intermediate-custom-naming-conventions.php
+++ b/examples/3-intermediate-custom-naming-conventions.php
@@ -15,7 +15,7 @@ require __DIR__ . '/repeated-sample-code.php';
 
 use League\Tactician\Command;
 use League\Tactician\StandardCommandBus;
-use League\Tactician\Handler\HandlerMiddleware;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\MethodNameInflector\MethodNameInflector;
 
 class MyCustomInflector implements MethodNameInflector
@@ -37,10 +37,10 @@ class NewRegisterUserHandler
     }
 }
 
-// Now  let's recreate our HandlerMiddleware again but with the naming scheme
+// Now  let's recreate our CommandHandlerMiddleware again but with the naming scheme
 // we prefer to use!
 $locator->addHandler(new NewRegisterUserHandler(), RegisterUserCommand::class);
-$handlerMiddleware = new HandlerMiddleware($locator, new MyCustomInflector());
+$handlerMiddleware = new CommandHandlerMiddleware($locator, new MyCustomInflector());
 
 $commandBus = new StandardCommandBus([$handlerMiddleware]);
 

--- a/examples/4-advanced-custom-handler-loading.php
+++ b/examples/4-advanced-custom-handler-loading.php
@@ -11,7 +11,7 @@ require __DIR__ . '/repeated-sample-code.php';
  */
 use League\Tactician\Command;
 use League\Tactician\StandardCommandBus;
-use League\Tactician\Handler\HandlerMiddleware;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\Locator\HandlerLocator;
 use League\Tactician\Handler\MethodNameInflector\HandleClassNameInflector;
 
@@ -40,7 +40,7 @@ $fakeContainer
     ->andReturn(new RegisterUserHandler());
 
 // Now, we create our command bus using our container based loader instead
-$handlerMiddleware = new HandlerMiddleware(
+$handlerMiddleware = new CommandHandlerMiddleware(
     new ContainerBasedHandlerLocator($fakeContainer),
     new HandleClassNameInflector()
 );

--- a/examples/repeated-sample-code.php
+++ b/examples/repeated-sample-code.php
@@ -25,7 +25,7 @@ class RegisterUserHandler
 $locator = new InMemoryLocator();
 $locator->addHandler(new RegisterUserHandler(), RegisterUserCommand::class);
 
-$handlerMiddleware = new League\Tactician\Handler\HandlerMiddleware(
+$handlerMiddleware = new League\Tactician\Handler\CommandHandlerMiddleware(
     $locator,
     new HandleClassNameInflector()
 );

--- a/src/Handler/CommandHandlerMiddleware.php
+++ b/src/Handler/CommandHandlerMiddleware.php
@@ -11,7 +11,7 @@ use League\Tactician\Handler\Locator\HandlerLocator;
 /**
  * The "core" CommandBus. Locates the appropriate handler and executes command.
  */
-class HandlerMiddleware implements Middleware
+class CommandHandlerMiddleware implements Middleware
 {
     /**
      * @var HandlerLocator

--- a/src/Setup/QuickStart.php
+++ b/src/Setup/QuickStart.php
@@ -5,7 +5,7 @@ use League\Tactician\CommandBus;
 use League\Tactician\StandardCommandBus;
 use League\Tactician\Handler\Locator\InMemoryLocator;
 use League\Tactician\Handler\MethodNameInflector\HandleInflector;
-use League\Tactician\Handler\HandlerMiddleware;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Plugins\LockingMiddleware;
 
 /**
@@ -30,7 +30,7 @@ class QuickStart
      */
     public static function create($commandToHandlerMap)
     {
-        $handlerMiddleware = new HandlerMiddleware(
+        $handlerMiddleware = new CommandHandlerMiddleware(
             new InMemoryLocator($commandToHandlerMap),
             new HandleInflector()
         );

--- a/tests/Handler/CommandHandlerMiddlewareTest.php
+++ b/tests/Handler/CommandHandlerMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 namespace League\Tactician\Tests\Handler;
 
-use League\Tactician\Handler\HandlerMiddleware;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\MethodNameInflector\MethodNameInflector;
 use League\Tactician\Handler\Locator\HandlerLocator;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
@@ -11,10 +11,10 @@ use League\Tactician\Tests\Fixtures\Handler\ConcreteMethodsHandler;
 use stdClass;
 use Mockery;
 
-class HandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
+class CommandHandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var HandlerMiddleware
+     * @var CommandHandlerMiddleware
      */
     private $middleware;
 
@@ -33,7 +33,7 @@ class HandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->handlerLocator = Mockery::mock(HandlerLocator::class);
         $this->methodNameInflector = Mockery::mock(MethodNameInflector::class);
 
-        $this->middleware = new HandlerMiddleware(
+        $this->middleware = new CommandHandlerMiddleware(
             $this->handlerLocator,
             $this->methodNameInflector
         );


### PR DESCRIPTION
I propose to rename HandlerMiddleware to CommandHandler.

The reason to rename HandlerMiddleware is that it in fact is not true middleware since it's a endpoint.
The second reason (and this is a pure personal one) is that the name confused me due to the fact that I expected it to handle middleware.