### PR TITLE
Using composer to register dev namespaces and load classes on global namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,14 @@
             "League\\Tactician\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "League\\Tactician\\Tests\\": "tests"
+        },
+        "files": [
+            "tests/Fixtures/Command/CommandWithoutNamespace.php"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.4-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
         >
 
     <listeners>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-/** @var \Composer\Autoload\ClassLoader $loader */
-$loader = require __DIR__.'/../vendor/autoload.php';
-$loader->addPsr4('League\\Tactician\\Tests\\', __DIR__);
-
-// In lieu of autoloading hacks, we'll just do it this way.
-require_once __DIR__.'/Fixtures/Command/CommandWithoutNamespace.php';


### PR DESCRIPTION
No need for autoloading hacks, as described in the former `bootstrap.php` file.