### PR TITLE
Dockblock and other code cleaning changes

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -2,16 +2,17 @@
 
 namespace League\Tactician;
 
-use Closure;
 use League\Tactician\Exception\InvalidCommandException;
 
 /**
  * Receives a command and sends it through a chain of middleware for processing.
+ *
+ * @final
  */
-/* final */class CommandBus
+class CommandBus
 {
     /**
-     * @var Closure
+     * @var \Closure
      */
     private $middlewareChain;
 
@@ -27,6 +28,7 @@ use League\Tactician\Exception\InvalidCommandException;
      * Executes the given command and optionally returns a value
      *
      * @param object $command
+     *
      * @return mixed
      */
     public function handle($command)
@@ -41,7 +43,8 @@ use League\Tactician\Exception\InvalidCommandException;
 
     /**
      * @param Middleware[] $middlewareList
-     * @return Closure
+     *
+     * @return \Closure
      */
     private function createExecutionChain($middlewareList)
     {

--- a/src/Exception/CanNotInvokeHandlerException.php
+++ b/src/Exception/CanNotInvokeHandlerException.php
@@ -18,6 +18,7 @@ class CanNotInvokeHandlerException extends \BadMethodCallException implements Ex
     /**
      * @param object $command
      * @param string $reason
+     *
      * @return static
      */
     public static function forCommand($command, $reason)

--- a/src/Exception/InvalidCommandException.php
+++ b/src/Exception/InvalidCommandException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace League\Tactician\Exception;
 
 /**
@@ -13,6 +14,7 @@ class InvalidCommandException extends \RuntimeException implements Exception
 
     /**
      * @param mixed $invalidCommand
+     *
      * @return static
      */
     public static function forUnknownValue($invalidCommand)

--- a/src/Exception/MissingHandlerException.php
+++ b/src/Exception/MissingHandlerException.php
@@ -14,6 +14,7 @@ class MissingHandlerException extends \OutOfBoundsException implements Exception
 
     /**
      * @param object $command
+     *
      * @return static
      */
     public static function forCommand($command)

--- a/src/Handler/CommandHandlerMiddleware.php
+++ b/src/Handler/CommandHandlerMiddleware.php
@@ -23,7 +23,7 @@ class CommandHandlerMiddleware implements Middleware
     private $methodNameInflector;
 
     /**
-     * @param HandlerLocator $handlerLoader
+     * @param HandlerLocator      $handlerLoader
      * @param MethodNameInflector $methodNameInflector
      */
     public function __construct(HandlerLocator $handlerLoader, MethodNameInflector $methodNameInflector)
@@ -35,10 +35,12 @@ class CommandHandlerMiddleware implements Middleware
     /**
      * Executes a command and optionally returns a value
      *
-     * @throws CanNotInvokeHandlerException
-     * @param object $command
+     * @param object   $command
      * @param callable $next
+     *
      * @return mixed
+     *
+     * @throws CanNotInvokeHandlerException
      */
     public function execute($command, callable $next)
     {

--- a/src/Handler/Locator/HandlerLocator.php
+++ b/src/Handler/Locator/HandlerLocator.php
@@ -14,6 +14,7 @@ interface HandlerLocator
      * Retrieves the handler for a specified command
      *
      * @param object $command
+     *
      * @return mixed
      */
     public function getHandlerForCommand($command);

--- a/src/Handler/Locator/InMemoryLocator.php
+++ b/src/Handler/Locator/InMemoryLocator.php
@@ -62,10 +62,8 @@ class InMemoryLocator implements HandlerLocator
     }
 
     /**
-     * Retrieve handler for the given command
+     * {@inheritdoc}
      *
-     * @param object $command
-     * @return object
      * @throws MissingHandlerException
      */
     public function getHandlerForCommand($command)

--- a/src/Handler/MethodNameInflector/MethodNameInflector.php
+++ b/src/Handler/MethodNameInflector/MethodNameInflector.php
@@ -13,6 +13,7 @@ interface MethodNameInflector
      *
      * @param object $command
      * @param object $commandHandler
+     *
      * @return string
      */
     public function inflect($command, $commandHandler);

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -15,8 +15,9 @@ namespace League\Tactician;
 interface Middleware
 {
     /**
-     * @param object $command
+     * @param object   $command
      * @param callable $next
+     *
      * @return mixed
      */
     public function execute($command, callable $next);

--- a/src/Plugins/LockingMiddleware.php
+++ b/src/Plugins/LockingMiddleware.php
@@ -23,9 +23,7 @@ class LockingMiddleware implements Middleware
     /**
      * Queues incoming commands until the first has completed
      *
-     * @param object $command
-     * @param callable $next
-     * @return mixed
+     * {@inheritdoc}
      */
     public function execute($command, callable $next)
     {

--- a/src/Setup/QuickStart.php
+++ b/src/Setup/QuickStart.php
@@ -26,6 +26,7 @@ class QuickStart
      * Creates a default CommandBus that you can get started with.
      *
      * @param array $commandToHandlerMap
+     *
      * @return CommandBus
      */
     public static function create($commandToHandlerMap)


### PR DESCRIPTION
Most important changes:

- Uses {@inheritdoc} where possible
- Improves readability
- Eliminates `/**final**/`, uses @final dockblock instead
- "Common" core PHP classes (eg. Closure) are not imported to the current namespace