### PR TITLE
Added HandleClassNameWithoutSuffixInflector

### DIFF
--- a/src/Handler/MethodNameInflector/HandleClassNameWithoutSuffixInflector.php
+++ b/src/Handler/MethodNameInflector/HandleClassNameWithoutSuffixInflector.php
@@ -1,0 +1,52 @@
+<?php
+namespace League\Tactician\Handler\MethodNameInflector;
+
+/**
+ * Returns a method name that is handle + the last portion of the class name
+ * but also without a given suffix, typically "Command". This allows you to
+ * handle multiple commands on a single object but with slightly less annoying
+ * method names.
+ *
+ * The string removal is case sensitive.
+ *
+ * Examples:
+ *  - \CompleteTaskCommand     => $handler->handleCompleteTask()
+ *  - \My\App\DoThingCommand   => $handler->handleDoThing()
+ */
+class HandleClassNameWithoutSuffixInflector extends HandleClassNameInflector
+{
+    /**
+     * @var string
+     */
+    private $suffix;
+
+    /**
+     * @var int
+     */
+    private $suffixLength;
+
+    /**
+     * @param string $suffix The string to remove from end of each class name
+     */
+    public function __construct($suffix = 'Command')
+    {
+        $this->suffix = $suffix;
+        $this->suffixLength = strlen($suffix);
+    }
+
+    /**
+     * @param object $command
+     * @param object $commandHandler
+     * @return string
+     */
+    public function inflect($command, $commandHandler)
+    {
+        $methodName = parent::inflect($command, $commandHandler);
+
+        if (substr($methodName, $this->suffixLength * -1) !== $this->suffix) {
+            return $methodName;
+        }
+
+        return substr($methodName, 0, strlen($methodName) - $this->suffixLength);
+    }
+}

--- a/tests/Handler/MethodNameInflector/HandleClassNameWithoutSuffixInflectorTest.php
+++ b/tests/Handler/MethodNameInflector/HandleClassNameWithoutSuffixInflectorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace League\Tactician\Tests\Handler\MethodNameInflector;
+
+use League\Tactician\Handler\MethodNameInflector\HandleClassNameWithoutSuffixInflector;
+use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
+use League\Tactician\Tests\Fixtures\Handler\ConcreteMethodsHandler;
+use DateTime;
+
+class HandleClassNameWithoutSuffixInflectorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HandleClassNameWithoutSuffixInflector
+     */
+    private $inflector;
+
+    /**
+     * @var object
+     */
+    private $mockHandler;
+
+    protected function setUp()
+    {
+        $this->inflector = new HandleClassNameWithoutSuffixInflector();
+        $this->handler = new ConcreteMethodsHandler();
+    }
+
+    public function testRemovesCommandSuffixFromClasses()
+    {
+        $command = new CompleteTaskCommand();
+
+        $this->assertEquals(
+            'handleCompleteTask',
+            $this->inflector->inflect($command, $this->mockHandler)
+        );
+    }
+
+    public function testDoesNotChangeClassesWithoutSuffix()
+    {
+        $this->assertEquals(
+            'handleDateTime',
+            $this->inflector->inflect(new DateTime(), $this->mockHandler)
+        );
+    }
+
+    public function testRemovesCustomSuffix()
+    {
+        $inflector = new HandleClassNameWithoutSuffixInflector('Time');
+
+        $this->assertEquals(
+            'handleDate',
+            $inflector->inflect(new DateTime(), $this->mockHandler)
+        );
+    }
+}


### PR DESCRIPTION
Terrible name, decent tweak.

Extending the class is a bit meh, but a decorator is overkill. Could easily split it out into a ClassNameUtils helper object with a couple of static methods, that might make it easier for people to remix.

Either way, this is easy to refactor later and I think it's a nice tweak. :)