### PR TITLE
Add Locator to retrieve Handlers from a Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "phpunit/phpunit": "~4.3",
         "squizlabs/php_codesniffer": "~2.3"
     },
+    "suggest": {
+        "container-interop/container-interop": "Allows loading a handler using a container"
+    },
     "autoload": {
         "psr-4": {
             "League\\Tactician\\": "src"

--- a/src/Handler/CommandNameExtractor/CommandHandlerNameExtractor.php
+++ b/src/Handler/CommandNameExtractor/CommandHandlerNameExtractor.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace League\Tactician\Handler\CommandNameExtractor;
+
+use League\Tactician\Exception\CanNotDetermineCommandNameException;
+
+/**
+ * Extract the name from a command so that the name can be determined
+ * by the context better than simply the class name
+ */
+interface CommandHandlerNameExtractor
+{
+    /**
+     * Extract the handler name from a command FQCN.
+     *
+     * @param string $command
+     *
+     * @return string
+     */
+    public function extract($command);
+}

--- a/src/Handler/CommandNameExtractor/IdentifierMapExtractor.php
+++ b/src/Handler/CommandNameExtractor/IdentifierMapExtractor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Tactician\Handler\CommandNameExtractor;
+
+/**
+ * Extract the an identifier based on the given map where the key of the map is the FQCN for the Command.
+ */
+class IdentifierMapExtractor implements CommandHandlerNameExtractor
+{
+    /**
+     * An identity map that maps the FQCN of a Command (as key) to an identifier (as value).
+     *
+     * @var string[]
+     */
+    private $identityMap = [];
+
+    /**
+     * Registers the identity map with this Extractor.
+     *
+     * @param string[] $identityMap
+     */
+    public function __construct(array $identityMap)
+    {
+        $this->identityMap = $identityMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract($command)
+    {
+        if (is_string($command) === false) {
+            throw new \InvalidArgumentException(
+                'A Command Handler Name Extractor expects the given command to be an FQCN'
+            );
+        }
+
+        if (isset($this->identityMap[$command]) === false) {
+            throw new \OutOfBoundsException('No identity known for Command of class "' . $command . '"');
+        }
+
+        return $this->identityMap[$command];
+    }
+}

--- a/src/Handler/CommandNameExtractor/SuffixedClassNameExtractor.php
+++ b/src/Handler/CommandNameExtractor/SuffixedClassNameExtractor.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace League\Tactician\Handler\CommandNameExtractor;
+
+/**
+ * Extract the name from the class with a suffix, defaults to 'Handler'.
+ */
+class SuffixedClassNameExtractor implements CommandHandlerNameExtractor
+{
+    /**
+     * @var string
+     */
+    private $suffix;
+
+    /**
+     * Determine the suffix to use.
+     *
+     * @param string $suffix
+     */
+    public function __construct($suffix = 'Handler')
+    {
+        $this->suffix = $suffix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract($command)
+    {
+        if (is_string($command) === false) {
+            throw new \InvalidArgumentException(
+                'A Command Handler Name Extractor expects the given command to be an FQCN'
+            );
+        }
+
+        return $command . $this->suffix;
+    }
+}

--- a/src/Handler/Locator/ContainerLocator.php
+++ b/src/Handler/Locator/ContainerLocator.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace League\Tactician\Handler\Locator;
+
+use Interop\Container\ContainerInterface;
+use League\Tactician\Exception\InvalidCommandException;
+use League\Tactician\Exception\MissingHandlerException;
+
+/**
+ * Fetch handler instances from a Dependency Injection Container supporting the Interop specification.
+ *
+ * This locator allows you to bind a handler object from a container to receive commands
+ * of a certain class name. For example:
+ *
+ *      // Instantiate locator
+ *      $containerLocator = new ContainerLocator($container);
+ *
+ *      // Returns an instance of 'My\TaskAddedHandler' from the container.
+ *      $containerLocator->getHandlerForCommand('My\TaskAddedCommand');
+ *
+ * The default behaviour for this locator is to take the Command's Fully Qualified Class Name, suffix it with
+ * 'Handler' and ask the container if a class with that name can be instantiated.
+ *
+ * Sometimes you want to specify the name of the handler yourself or you container uses identifiers to retrieve objects,
+ * in this case it is possible to provide a second argument to the constructor, or use the addHandler method, to
+ * provide the name with which the handler will be located in the Dependency Injection Container.
+ *
+ * For example:
+ *
+ *      // Instantiate locator using mapping array
+ *      $containerLocator = new ContainerLocator($container, [ 'My\TaskAddedCommand' => 'my.handler.identifier' ]);
+ *
+ *      // Or by using the addHandler method
+ *      $containerLocator->addHandler('My\TaskRemovedCommand', 'my.handler.removed.identifier');
+ *
+ *      // Returns an the instance belonging to the key 'my.handler.identifier' from the container.
+ *      $containerLocator->getHandlerForCommand('My\TaskAddedCommand');
+ */
+final class ContainerLocator implements HandlerLocator
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /** @var string a mapping where the key is the FQCN of the Command and the value is the FQCN of the Handler */
+    private $handlers = [];
+
+    /**
+     * Initializes a mapping between a Command and a Handler, if no mapping is provided then the Handler is found by
+     * appending the suffix 'Handler' to the FQCN of the Command.
+     *
+     * @param ContainerInterface $container
+     * @param string[]           $commandClassToHandlerMap
+     */
+    public function __construct(ContainerInterface $container, array $commandClassToHandlerMap = [])
+    {
+        $this->container = $container;
+        $this->addHandlers($commandClassToHandlerMap);
+    }
+
+    /**
+     * Bind a handler class name to receive all commands with a certain class
+     *
+     * @param string $handler          Handler class to receive command, e.g. "My\TaskAddedCommandHandler"
+     * @param string $commandClassName Command class e.g. "My\TaskAddedCommand"
+     */
+    public function addHandler($handler, $commandClassName)
+    {
+        $this->handlers[$commandClassName] = $handler;
+    }
+
+    /**
+     * Allows you to add multiple handlers at once.
+     *
+     * The map should be an array in the format of:
+     *  [
+     *      AddTaskCommand::class      => AddTaskCommandHandler::class,
+     *      CompleteTaskCommand::class => CompleteTaskCommandHandler::class,
+     *  ]
+     *
+     * @param array $commandClassToHandlerMap
+     */
+    protected function addHandlers(array $commandClassToHandlerMap)
+    {
+        foreach ($commandClassToHandlerMap as $commandClass => $handler) {
+            $this->addHandler($handler, $commandClass);
+        }
+    }
+
+    /**
+     * Retrieves the handler for a specified command class.
+     *
+     * @param string $commandName
+     *
+     * @throws InvalidCommandException if the provided command name does not match an existing class.
+     * @throws MissingHandlerException if no suitable handler could be found.
+     *
+     * @return object
+     */
+    public function getHandlerForCommand($commandName)
+    {
+        $handlerName = $this->determineHandlerIdentifier($commandName);
+
+        try {
+            $handler = $this->retrieveHandlerFromContainer($handlerName);
+        } catch (\OutOfBoundsException $e) {
+            throw MissingHandlerException::forCommand($commandName);
+        }
+
+        return $handler;
+    }
+
+    /**
+     * Returns the handler identifier with the command mapping for the given commandName or appends the
+     * suffix 'Handler' and returns that.
+     *
+     * @param string $commandName
+     *
+     * @return string
+     */
+    private function determineHandlerIdentifier($commandName)
+    {
+        $handlerName = isset($this->handlers[$commandName])
+            ? $this->handlers[$commandName]
+            : $commandName . 'Handler';
+
+        if (is_string($commandName) === false || class_exists($commandName) === false) {
+            throw InvalidCommandException::forUnknownValue($commandName);
+        }
+
+        return $handlerName;
+    }
+
+    /**
+     * Fetches the handler from the container with the provided identifier.
+     *
+     * @param string $handlerIdentifier
+     *
+     * @throws \OutOfBoundsException if the container does not return an object.
+     * @throws \OutOfBoundsException if the container throws an error when retrieving the handler.
+
+     * @return object
+     */
+    private function retrieveHandlerFromContainer($handlerIdentifier)
+    {
+        try {
+            $handler = $this->container->get($handlerIdentifier);
+            if (is_object($handler) === false) {
+                throw new \OutOfBoundsException();
+            }
+        } catch (\Exception $e) {
+            throw new \OutOfBoundsException();
+        }
+
+        return $handler;
+    }
+}

--- a/src/Handler/Locator/InMemoryLocator.php
+++ b/src/Handler/Locator/InMemoryLocator.php
@@ -15,7 +15,7 @@ use League\Tactician\Exception\MissingHandlerException;
  *      $inMemoryLocator->addHandler($myHandler, 'My\TaskAddedCommand');
  *
  *      // Returns $myHandler
- *      $inMemoryLocator->getHandlerForCommand(new My\TaskAddedCommand());
+ *      $inMemoryLocator->getHandlerForCommand('My\TaskAddedCommand');
  */
 class InMemoryLocator implements HandlerLocator
 {

--- a/tests/Fixtures/Handler/DummyCommand.php
+++ b/tests/Fixtures/Handler/DummyCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace League\Tactician\Tests\Fixtures\Handler;
+
+/**
+ * A Dummy CommandHandler that is needed because the CommandLocator needs a real class.
+ *
+ * @see \League\Tactician\Tests\Handler\Locator\CommandLocatorTest
+ */
+class DummyCommand
+{
+
+}

--- a/tests/Fixtures/Handler/DummyCommandHandler.php
+++ b/tests/Fixtures/Handler/DummyCommandHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace League\Tactician\Tests\Fixtures\Handler;
+
+/**
+ * A Dummy CommandHandler that is needed because the CommandLocator needs a real class.
+ *
+ * @see \League\Tactician\Tests\Handler\Locator\CommandLocatorTest
+ */
+class DummyCommandHandler
+{
+
+}

--- a/tests/Handler/Locator/ContainerLocatorTest.php
+++ b/tests/Handler/Locator/ContainerLocatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace League\Tactician\Tests\Handler\Locator;
+
+use League\Tactician\Handler\Locator\ContainerLocator;
+use League\Tactician\Tests\Fixtures\Handler\DummyCommand;
+use League\Tactician\Tests\Fixtures\Handler\DummyCommandHandler;
+use Mockery as m;
+
+class ContainerLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIfHandlerIsReturnedForAProvidedCommandMapping()
+    {
+        $handler = new \stdClass();
+        $containerMock = m::mock('Interop\Container\ContainerInterface');
+        $containerMock->shouldReceive('get')->with('stdClass')->andReturn($handler);
+        $fixture = new ContainerLocator($containerMock, ['stdClass' => 'stdClass']);
+
+        $receivedHandler = $fixture->getHandlerForCommand('stdClass');
+
+        $this->assertSame($receivedHandler, $handler);
+    }
+
+    public function testIfHandlerIsWhenACommandMappingIsNotProvided()
+    {
+        $handler = new DummyCommandHandler();
+        $containerMock = m::mock('Interop\Container\ContainerInterface');
+        $containerMock->shouldReceive('get')->with(DummyCommandHandler::class)->andReturn($handler);
+        $fixture = new ContainerLocator($containerMock);
+
+        $receivedHandler = $fixture->getHandlerForCommand(DummyCommand::class);
+
+        $this->assertSame($receivedHandler, $handler);
+    }
+
+    /**
+     * @expectedException League\Tactician\Exception\InvalidCommandException
+     */
+    public function testIfAnErrorOccursIfCommandClassDoesNotExist()
+    {
+        $containerMock = m::mock('Interop\Container\ContainerInterface');
+        $fixture = new ContainerLocator($containerMock);
+
+        $fixture->getHandlerForCommand('UnknownCommandClass');
+    }
+
+    /**
+     * @expectedException League\Tactician\Exception\MissingHandlerException
+     */
+    public function testIfAnErrorOccursIfContainerDoesNotReturnObject()
+    {
+        $containerMock = m::mock('Interop\Container\ContainerInterface');
+        $containerMock->shouldReceive('get')->with('stdClass')->andReturn('notAnObject');
+        $fixture = new ContainerLocator($containerMock, ['stdClass' => 'stdClass']);
+
+        $fixture->getHandlerForCommand('stdClass');
+    }
+
+    /**
+     * @expectedException League\Tactician\Exception\MissingHandlerException
+     */
+    public function testIfAnErrorOccursIfContainerThrowsAnExceptionWhenRetrievingAHandler()
+    {
+        $containerMock = m::mock('Interop\Container\ContainerInterface');
+        $containerMock->shouldReceive('get')->with('stdClass')->andThrow(new \Exception());
+        $fixture = new ContainerLocator($containerMock, ['stdClass' => 'stdClass']);
+
+        $fixture->getHandlerForCommand('stdClass');
+    }
+}


### PR DESCRIPTION
In this PR I have added a Locator that is capable of retrieving
a handler from a Container implementing the Container Interop
standard / shared interface.

The Locator's default behaviour is to append the suffix 'Handler' to
the given Command Name (assuming the Command Name is an FQCN)
and uses that to find a handler in the Container that is provided
in the constructor.

A secondary behaviour for the Locator is that you can pass a map with
which you can map command names to specific identifiers with which
a handler can be returned. This is especially convenient when you are
using a container that operates based on identifiers and not class
names.

This specific locator depends on the `container-interop/container-interop`
package but I have explicitly mentioned this in the suggest section
of the composer because it is not a hard requirement for the usage of
Tactician, only when you want to use this new Locator.

Using unit tests and by manually performing tests using dummy data
I have been able to verify that no errors occur due to omitting this
dependency by default.