### PR TITLE
Pushing code coverage report to Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,3 +4,4 @@ tools:
     php_sim: true
     php_pdepend: true
     php_analyzer: true
+    external_code_coverage: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,12 @@ matrix:
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
+    - travis_retry wget https://scrutinizer-ci.com/ocular.phar
+    - mkdir -p build/logs
 
 script:
-    - vendor/bin/phpunit
+    - vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
     - vendor/bin/phpcs --standard=PSR2 src tests
+
+after_script:
+    - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis CI](https://api.travis-ci.org/thephpleague/tactician.svg?branch=master)](https://travis-ci.org/thephpleague/tactician)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/thephpleague/tactician/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/thephpleague/tactician/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/thephpleague/tactician/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/thephpleague/tactician/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/thephpleague/tactician/badges/build.png?b=master)](https://scrutinizer-ci.com/g/thephpleague/tactician/build-status/master)
 [![MIT License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/thephpleague/tactician/blob/master/LICENSE)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/54275a78-bc70-4bb3-9ac4-4eee700c6a1c/small.png)](https://insight.sensiolabs.com/projects/54275a78-bc70-4bb3-9ac4-4eee700c6a1c)


### PR DESCRIPTION
Currently getting 99% code coverage according to https://scrutinizer-ci.com/g/renan/tactician/?branch=code-coverage

The only method not being coverage is [`CanNotDetermineCommandNameException::getCommand()`](https://scrutinizer-ci.com/g/renan/tactician/code-structure/code-coverage/class/League%5CTactician%5CException%5CCanNotDetermineCommandNameException)