### PR TITLE
Add bootstrap file for phpunit using composers autoloader

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+include(dirname(__FILE__) . '/../vendor/autoload.php');


### PR DESCRIPTION
Running PHPUnit fatals on missing files, since it has no autoloader registered from composer.

I added a bootstrap file to load that in.