### PR TITLE
Fix HTTP URLs for shields.io badges on plugin pages

### DIFF
--- a/plugins/bernard.md
+++ b/plugins/bernard.md
@@ -6,9 +6,9 @@ title: Bernard
 
 # Bernard
 
-[![Author](http://img.shields.io/badge/author-@sagikazarmark-blue.svg?style=flat-square)](https://twitter.com/sagikazarmark)
-[![Source](http://img.shields.io/badge/source-league/tactician--bernard-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-bernard)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician-bernard.svg?style=flat-square)](https://packagist.org/packages/league/tactician-bernard)
+[![Author](https://img.shields.io/badge/author-@sagikazarmark-blue.svg?style=flat-square)](https://twitter.com/sagikazarmark)
+[![Source](https://img.shields.io/badge/source-league/tactician--bernard-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-bernard)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician-bernard.svg?style=flat-square)](https://packagist.org/packages/league/tactician-bernard)
 
 
 This plugin provides you tools for both sending commands to and consuming from a queue.

--- a/plugins/command-events.md
+++ b/plugins/command-events.md
@@ -6,9 +6,9 @@ title: Command Events
 
 # Command Events
 
-[![Author](http://img.shields.io/badge/author-@sagikazarmark-blue.svg?style=flat-square)](https://twitter.com/sagikazarmark)
-[![Source](http://img.shields.io/badge/source-league/tactician--command--events-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-command-events)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician-command-events.svg?style=flat-square)](https://packagist.org/packages/league/tactician-command-events)
+[![Author](https://img.shields.io/badge/author-@sagikazarmark-blue.svg?style=flat-square)](https://twitter.com/sagikazarmark)
+[![Source](https://img.shields.io/badge/source-league/tactician--command--events-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-command-events)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician-command-events.svg?style=flat-square)](https://packagist.org/packages/league/tactician-command-events)
 
 This plugin lets you listen to some events emitted during command execution:
 

--- a/plugins/doctrine.md
+++ b/plugins/doctrine.md
@@ -6,9 +6,9 @@ title: Doctrine
 
 # Doctrine
 
-[![Author](http://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
-[![Source](http://img.shields.io/badge/source-league/tactician--doctrine-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-doctrine)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician-doctrine.svg?style=flat-square)](https://packagist.org/packages/league/tactician-doctrine)
+[![Author](https://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
+[![Source](https://img.shields.io/badge/source-league/tactician--doctrine-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-doctrine)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician-doctrine.svg?style=flat-square)](https://packagist.org/packages/league/tactician-doctrine)
 
 This package provides a `TransactionMiddleware` that executes each command in a separate Doctrine ORM transaction.
 

--- a/plugins/league-container.md
+++ b/plugins/league-container.md
@@ -6,9 +6,9 @@ title: League\Container
 
 # League\Container
 
-[![Author](http://img.shields.io/badge/author-@NigelGreenway-blue.svg?style=flat-square)](https://twitter.com/nigelgreenway)
-[![Source](http://img.shields.io/badge/source-league/tactician--container-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-container)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician-container.svg?style=flat-square)](https://packagist.org/packages/league/tactician-container)
+[![Author](https://img.shields.io/badge/author-@NigelGreenway-blue.svg?style=flat-square)](https://twitter.com/nigelgreenway)
+[![Source](https://img.shields.io/badge/source-league/tactician--container-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-container)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician-container.svg?style=flat-square)](https://packagist.org/packages/league/tactician-container)
 
 This plugin adds support for lazy-loading Command Handlers from [League\Container](http://container.thephpleague.com/). If you're using Container in your project, this plugin will likely improve your memory usage and startup times compared to the InMemoryHandlerLocator that Tactician ships with by default.
   

--- a/plugins/locking-middleware.md
+++ b/plugins/locking-middleware.md
@@ -6,9 +6,9 @@ title: Locking Middleware
 
 # Locking Middleware
 
-[![Author](http://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
-[![Source](http://img.shields.io/badge/source-league/tactician-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician.svg?style=flat-square)](https://packagist.org/packages/league/tactician)
+[![Author](https://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
+[![Source](https://img.shields.io/badge/source-league/tactician-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician.svg?style=flat-square)](https://packagist.org/packages/league/tactician)
 
 This plugin actually ships in the core Tactician "CommandBus" package, so it's available without installing any separate composer packages.
 

--- a/plugins/logger.md
+++ b/plugins/logger.md
@@ -6,9 +6,9 @@ title: Logger
 
 # Logger
 
-[![Author](http://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
-[![Source](http://img.shields.io/badge/source-league/tactician--logger-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-logger)
-[![Packagist](http://img.shields.io/packagist/v/league/tactician-logger.svg?style=flat-square)](https://packagist.org/packages/league/tactician-logger)
+[![Author](https://img.shields.io/badge/author-@rosstuck-blue.svg?style=flat-square)](https://twitter.com/rosstuck)
+[![Source](https://img.shields.io/badge/source-league/tactician--logger-blue.svg?style=flat-square)](https://github.com/thephpleague/tactician-logger)
+[![Packagist](https://img.shields.io/packagist/v/league/tactician-logger.svg?style=flat-square)](https://packagist.org/packages/league/tactician-logger)
 
 During development, logging can help visualize the flow commands take in the system. The `league\tactician-logger` package provides out-of-the-box support for logging command data to any [PSR-3 compliant logger](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) (so, basically all of them). 
 


### PR DESCRIPTION
This suppresses mixed content warnings by browsers when viewing the site over HTTPS.