### PR TITLE
Fix incorrect example

### DIFF
--- a/plugins/league-container.md
+++ b/plugins/league-container.md
@@ -32,6 +32,7 @@ $containerLocator = new ContainerLocator(
 // Finally, we pass the ContainerLocator into the CommandHandlerMiddleware that
 // we use in almost every CommandBus.
 $commandHandlerMiddleware = new CommandHandlerMiddleware(
+    new ClassNameExtractor(),
     $containerLocator,
     new HandleInflector()
 )


### PR DESCRIPTION
[CommandHandlerMiddleware](https://github.com/thephpleague/tactician/blob/master/src/Handler/CommandHandlerMiddleware.php#L36) takes a CommandNameExtractor concrete implementation as it's first argument