### PR TITLE
Added function to modify the middleware chain

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -45,7 +45,7 @@ class CommandBus
 
     /**
      * Put some middleware on the front of the middleware chain.
-     * 
+     *
      * @param \League\Tactician\Middleware $middleware
      */
     public function prependMiddlewareChain(Middleware $middleware)

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -26,7 +26,7 @@ class CommandBus
     }
 
     /**
-     * Executes the given command and optionally returns a value
+     * Executes the given command and optionally returns a value.
      *
      * @param object $command
      *
@@ -39,23 +39,24 @@ class CommandBus
         }
 
         $middlewareChain = $this->middlewareChain;
+
         return $middlewareChain($command);
     }
-    
-    /**
-     * Put some middleware on the front of the middleware chain
+
+/**
+     * Put some middleware on the front of the middleware chain.
      * 
      * @param \League\Tactician\Middleware $middleware
      */
-    public function prependMiddlewareChain(Middleware $middleware) {
+    public function prependMiddlewareChain(Middleware $middleware)
+    {
         $oldMiddlewareChain = $this->middlewareChain;
-        $this->middlewareChain = function($command) use ($middleware, $oldMiddlewareChain) {
+        $this->middlewareChain = function ($command) use ($middleware, $oldMiddlewareChain) {
             return $middleware->execute($command, $oldMiddlewareChain);
         };
     }
-    
 
-    /**
+/**
      * @param Middleware[] $middlewareList
      *
      * @return callable
@@ -67,7 +68,7 @@ class CommandBus
         };
 
         while ($middleware = array_pop($middlewareList)) {
-            if (! $middleware instanceof Middleware) {
+            if (!$middleware instanceof Middleware) {
                 throw InvalidMiddlewareException::forMiddleware($middleware);
             }
 

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -20,7 +20,7 @@ class CommandBus
     /**
      * @param Middleware[] $middleware
      */
-    public function __construct(array $middleware)
+    public function __construct(array $middleware = array())
     {
         $this->middlewareChain = $this->createExecutionChain($middleware);
     }
@@ -41,6 +41,19 @@ class CommandBus
         $middlewareChain = $this->middlewareChain;
         return $middlewareChain($command);
     }
+    
+    /**
+     * Put some middleware on the front of the middleware chain
+     * 
+     * @param \League\Tactician\Middleware $middleware
+     */
+    public function prependMiddlewareChain(Middleware $middleware) {
+        $oldMiddlewareChain = $this->middlewareChain;
+        $this->middlewareChain = function($command) use ($middleware, $oldMiddlewareChain) {
+            return $middleware->execute($command, $oldMiddlewareChain);
+        };
+    }
+    
 
     /**
      * @param Middleware[] $middlewareList

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -43,7 +43,7 @@ class CommandBus
         return $middlewareChain($command);
     }
 
-/**
+    /**
      * Put some middleware on the front of the middleware chain.
      * 
      * @param \League\Tactician\Middleware $middleware
@@ -56,7 +56,7 @@ class CommandBus
         };
     }
 
-/**
+    /**
      * @param Middleware[] $middlewareList
      *
      * @return callable

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace League\Tactician\Tests;
+
+namespace League\Tactician\tests;
 
 use League\Tactician\CommandBus;
-use League\Tactician\Exception\InvalidMiddlewareException;
 use League\Tactician\Middleware;
 use League\Tactician\Tests\Fixtures\Command\AddTaskCommand;
 use Mockery;
@@ -17,6 +17,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $middleware1->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 1;
+
                 return $next($command);
             }
         );
@@ -25,6 +26,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $middleware2->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 2;
+
                 return $next($command);
             }
         );
@@ -33,6 +35,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $middleware3->shouldReceive('execute')->andReturnUsing(
             function () use (&$executionOrder) {
                 $executionOrder[] = 3;
+
                 return 'foobar';
             }
         );
@@ -42,14 +45,16 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $commandBus->handle(new AddTaskCommand()));
         $this->assertEquals([1, 2, 3], $executionOrder);
     }
-    
-    public function testMiddlewareCanBeAddedLater() {
+
+    public function testMiddlewareCanBeAddedLater()
+    {
         $executionOrder = [];
 
         $middleware1 = Mockery::mock(Middleware::class);
         $middleware1->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 1;
+
                 return $next($command);
             }
         );
@@ -58,6 +63,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $middleware2->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 2;
+
                 return $next($command);
             }
         );
@@ -66,6 +72,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $middleware3->shouldReceive('execute')->andReturnUsing(
             function () use (&$executionOrder) {
                 $executionOrder[] = 3;
+
                 return 'foobar';
             }
         );

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -42,6 +42,42 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $commandBus->handle(new AddTaskCommand()));
         $this->assertEquals([1, 2, 3], $executionOrder);
     }
+    
+    public function testMiddlewareCanBeAddedLater() {
+        $executionOrder = [];
+
+        $middleware1 = Mockery::mock(Middleware::class);
+        $middleware1->shouldReceive('execute')->andReturnUsing(
+            function ($command, $next) use (&$executionOrder) {
+                $executionOrder[] = 1;
+                return $next($command);
+            }
+        );
+
+        $middleware2 = Mockery::mock(Middleware::class);
+        $middleware2->shouldReceive('execute')->andReturnUsing(
+            function ($command, $next) use (&$executionOrder) {
+                $executionOrder[] = 2;
+                return $next($command);
+            }
+        );
+
+        $middleware3 = Mockery::mock(Middleware::class);
+        $middleware3->shouldReceive('execute')->andReturnUsing(
+            function () use (&$executionOrder) {
+                $executionOrder[] = 3;
+                return 'foobar';
+            }
+        );
+
+        $commandBus = new CommandBus();
+        $commandBus->prependMiddlewareChain($middleware3);
+        $commandBus->prependMiddlewareChain($middleware2);
+        $commandBus->prependMiddlewareChain($middleware1);
+
+        $this->assertEquals('foobar', $commandBus->handle(new AddTaskCommand()));
+        $this->assertEquals([1, 2, 3], $executionOrder);
+    }
 
     public function testSingleMiddlewareWorks()
     {


### PR DESCRIPTION
Hi,

I've added a function to the command bus to modify the middleware chain after creating it. Given the nature of the chain I don't see a way (yet) to add something to the end of the chain, only to the beginning. I think this gives users more flexibility in building the command bus and I prefer the syntax of a several method calls over passing everything in a constructor.