### PR TITLE
Link to Zend Framework 2 command/handler generator

### DIFF
--- a/plugins/community-plugins.md
+++ b/plugins/community-plugins.md
@@ -14,3 +14,9 @@ Composer        | Github           | Author  |
 --------------- | ---------------- | ------- |
 [connectholland/tactician-scheduler-plugin](https://packagist.org/packages/connectholland/tactician-scheduler-plugin) | [ConnectHolland/tactician-scheduler-plugin](https://github.com/ConnectHolland/tactician-scheduler-plugin) | [Ron Rademaker](https://github.com/RonRademaker) |
 
+
+## Zf2 Command Generator CLI tool by @CodeMineDev
+Composer        | Github           | Author  |
+--------------- | ---------------- | ------- |
+[code-mine/zf-tactician-comandquery-generator](https://packagist.org/packages/code-mine/zf-tactician-comandquery-generator) | [Code-Mine-Development/CommandQueryGenerator](https://github.com/Code-Mine-Development/CommandQueryGenerator) | [Code Mine](http://code-mine.com) |
+


### PR DESCRIPTION
Added link to Zend Framework 2 command/handler skeleton generator. It'a a CLI module for ZF2 applications.