### PR TITLE
docs: `getHandlerForCommand` receives the command name, not the Command object

### DIFF
--- a/src/Handler/Locator/InMemoryLocator.php
+++ b/src/Handler/Locator/InMemoryLocator.php
@@ -15,7 +15,7 @@ use League\Tactician\Exception\MissingHandlerException;
  *      $inMemoryLocator->addHandler($myHandler, 'My\TaskAddedCommand');
  *
  *      // Returns $myHandler
- *      $inMemoryLocator->getHandlerForCommand(new My\TaskAddedCommand());
+ *      $inMemoryLocator->getHandlerForCommand('My\TaskAddedCommand');
  */
 class InMemoryLocator implements HandlerLocator
 {


### PR DESCRIPTION
Just a small change in the `InMemoryLocator` class docs.