### PR TITLE
Fix: Namespace does not match project structure

### DIFF
--- a/tests/Exception/CanNotDetermineCommandNameExceptionTest.php
+++ b/tests/Exception/CanNotDetermineCommandNameExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tactician\CommandBus\Tests\Exception;
+namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\CanNotDetermineCommandNameException;
 

--- a/tests/Exception/CanNotInvokeHandlerExceptionTest.php
+++ b/tests/Exception/CanNotInvokeHandlerExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tactician\CommandBus\Tests\Exception;
+namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\CanNotInvokeHandlerException;
 use League\Tactician\Exception\Exception;

--- a/tests/Exception/InvalidCommandExceptionTest.php
+++ b/tests/Exception/InvalidCommandExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tactician\CommandBus\Tests\Exception;
+namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\InvalidCommandException;
 use League\Tactician\Exception\Exception;

--- a/tests/Exception/MissingHandlerExceptionTest.php
+++ b/tests/Exception/MissingHandlerExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tactician\CommandBus\Tests\Exception;
+namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\MissingHandlerException;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;


### PR DESCRIPTION
This PR

* [x] fixes namespaces of tests which do not match the project structure