### PR TITLE
Fix: Limit range of accepted PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php":  ">=5.5"
+        "php":  "^5.5 || ^7.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
This PR

* [x] limits the range of accepted PHP versions

💁 We can't tell for sure yet whether this package will be compatible with PHP 9000, can we?