### PR TITLE
PHP 5.4 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 vendor/
 composer.lock
 phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor/
 composer.lock
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+    - 5.4
     - 5.5
     - 5.6
     - 7.0
@@ -8,6 +9,8 @@ php:
 
 matrix:
     include:
+        - php: 5.4
+          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
         - php: 5.5
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php":  ">=5.5"
+        "php":  ">=5.4"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/examples/1-beginner-standard-usage.php
+++ b/examples/1-beginner-standard-usage.php
@@ -23,7 +23,7 @@ class RegisterUserHandler
 
 // Setup the bus, normally in your DI container ///////////////////////////////
 $locator = new InMemoryLocator();
-$locator->addHandler(new RegisterUserHandler(), RegisterUserCommand::class);
+$locator->addHandler(new RegisterUserHandler(), 'RegisterUserCommand');
 
 // Middleware is Tactician's plugin system. Even finding the handler and
 // executing it is a plugin that we're configuring here.

--- a/examples/3-intermediate-custom-naming-conventions.php
+++ b/examples/3-intermediate-custom-naming-conventions.php
@@ -38,7 +38,7 @@ class NewRegisterUserHandler
 
 // Now  let's recreate our CommandHandlerMiddleware again but with the naming scheme
 // we prefer to use!
-$locator->addHandler(new NewRegisterUserHandler(), RegisterUserCommand::class);
+$locator->addHandler(new NewRegisterUserHandler(), 'RegisterUserCommand');
 $handlerMiddleware = new CommandHandlerMiddleware(new ClassNameExtractor(), $locator, new MyCustomInflector());
 
 $commandBus = new CommandBus([$handlerMiddleware]);

--- a/examples/repeated-sample-code.php
+++ b/examples/repeated-sample-code.php
@@ -23,7 +23,7 @@ class RegisterUserHandler
 }
 
 $locator = new InMemoryLocator();
-$locator->addHandler(new RegisterUserHandler(), RegisterUserCommand::class);
+$locator->addHandler(new RegisterUserHandler(), 'RegisterUserCommand');
 
 $handlerMiddleware = new League\Tactician\Handler\CommandHandlerMiddleware(
     new ClassNameExtractor(),

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -12,7 +12,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
     {
         $executionOrder = [];
 
-        $middleware1 = Mockery::mock(Middleware::class);
+        $middleware1 = Mockery::mock('League\\Tactician\\Middleware');
         $middleware1->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 1;
@@ -20,7 +20,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $middleware2 = Mockery::mock(Middleware::class);
+        $middleware2 = Mockery::mock('League\\Tactician\\Middleware');
         $middleware2->shouldReceive('execute')->andReturnUsing(
             function ($command, $next) use (&$executionOrder) {
                 $executionOrder[] = 2;
@@ -28,7 +28,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $middleware3 = Mockery::mock(Middleware::class);
+        $middleware3 = Mockery::mock('League\\Tactician\\Middleware');
         $middleware3->shouldReceive('execute')->andReturnUsing(
             function () use (&$executionOrder) {
                 $executionOrder[] = 3;
@@ -44,7 +44,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleMiddlewareWorks()
     {
-        $middleware = Mockery::mock(Middleware::class);
+        $middleware = Mockery::mock('League\\Tactician\\Middleware');
         $middleware->shouldReceive('execute')->once()->andReturn('foobar');
 
         $commandBus = new CommandBus([$middleware]);

--- a/tests/Exception/CanNotInvokeHandlerExceptionTest.php
+++ b/tests/Exception/CanNotInvokeHandlerExceptionTest.php
@@ -3,7 +3,6 @@
 namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\CanNotInvokeHandlerException;
-use League\Tactician\Exception\Exception;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
 
 class CanNotInvokeHandlerExceptionTest extends \PHPUnit_Framework_TestCase
@@ -14,10 +13,10 @@ class CanNotInvokeHandlerExceptionTest extends \PHPUnit_Framework_TestCase
 
         $exception = CanNotInvokeHandlerException::forCommand($command, 'Because stuff');
 
-        $this->assertContains(CompleteTaskCommand::class, $exception->getMessage());
+        $this->assertContains(get_class($command), $exception->getMessage());
         $this->assertContains('Because stuff', $exception->getMessage());
         $this->assertSame($command, $exception->getCommand());
-        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf('League\\Tactician\\Exception\\Exception', $exception);
     }
 
     /**

--- a/tests/Exception/InvalidCommandExceptionTest.php
+++ b/tests/Exception/InvalidCommandExceptionTest.php
@@ -3,7 +3,6 @@
 namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\InvalidCommandException;
-use League\Tactician\Exception\Exception;
 
 class InvalidCommandExceptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,6 +14,6 @@ class InvalidCommandExceptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('type: string', $exception->getMessage());
         $this->assertSame($command, $exception->getInvalidCommand());
-        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf('League\\Tactician\\Exception\\Exception', $exception);
     }
 }

--- a/tests/Exception/MissingHandlerExceptionTest.php
+++ b/tests/Exception/MissingHandlerExceptionTest.php
@@ -3,17 +3,17 @@
 namespace League\Tactician\Tests\Exception;
 
 use League\Tactician\Exception\MissingHandlerException;
-use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
-use League\Tactician\Exception\Exception;
 
 class MissingHandlerExceptionTest extends \PHPUnit_Framework_TestCase
 {
+    const FIXTURE_COMMAND_CLASS = 'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand';
+
     public function testExceptionContainsDebuggingInfo()
     {
-        $exception = MissingHandlerException::forCommand(CompleteTaskCommand::class);
+        $exception = MissingHandlerException::forCommand(self::FIXTURE_COMMAND_CLASS);
 
-        $this->assertContains(CompleteTaskCommand::class, $exception->getMessage());
-        $this->assertSame(CompleteTaskCommand::class, $exception->getCommandName());
-        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertContains(self::FIXTURE_COMMAND_CLASS, $exception->getMessage());
+        $this->assertSame(self::FIXTURE_COMMAND_CLASS, $exception->getCommandName());
+        $this->assertInstanceOf('League\\Tactician\\Exception\\Exception', $exception);
     }
 }

--- a/tests/Handler/CommandHandlerMiddlewareTest.php
+++ b/tests/Handler/CommandHandlerMiddlewareTest.php
@@ -34,9 +34,13 @@ class CommandHandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->commandNameExtractor = Mockery::mock('League\\Tactician\\Handler\\CommandNameExtractor\\CommandNameExtractor');
+        $this->commandNameExtractor = Mockery::mock(
+            'League\\Tactician\\Handler\\CommandNameExtractor\\CommandNameExtractor'
+        );
         $this->handlerLocator = Mockery::mock('League\\Tactician\\Handler\\Locator\\HandlerLocator');
-        $this->methodNameInflector = Mockery::mock('League\\Tactician\\Handler\\MethodNameInflector\\MethodNameInflector');
+        $this->methodNameInflector = Mockery::mock(
+            'League\\Tactician\\Handler\\MethodNameInflector\\MethodNameInflector'
+        );
 
         $this->middleware = new CommandHandlerMiddleware(
             $this->commandNameExtractor,

--- a/tests/Handler/CommandHandlerMiddlewareTest.php
+++ b/tests/Handler/CommandHandlerMiddlewareTest.php
@@ -3,12 +3,10 @@
 namespace League\Tactician\Tests\Handler;
 
 use League\Tactician\Handler\CommandHandlerMiddleware;
-use League\Tactician\Handler\CommandNameExtractor\CommandNameExtractor;
 use League\Tactician\Handler\Locator\HandlerLocator;
 use League\Tactician\Handler\MethodNameInflector\MethodNameInflector;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
 use League\Tactician\Tests\Fixtures\Handler\DynamicMethodsHandler;
-use League\Tactician\Tests\Fixtures\Handler\ConcreteMethodsHandler;
 use stdClass;
 use Mockery;
 
@@ -36,9 +34,9 @@ class CommandHandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->commandNameExtractor = Mockery::mock(CommandNameExtractor::class);
-        $this->handlerLocator = Mockery::mock(HandlerLocator::class);
-        $this->methodNameInflector = Mockery::mock(MethodNameInflector::class);
+        $this->commandNameExtractor = Mockery::mock('League\\Tactician\\Handler\\CommandNameExtractor\\CommandNameExtractor');
+        $this->handlerLocator = Mockery::mock('League\\Tactician\\Handler\\Locator\\HandlerLocator');
+        $this->methodNameInflector = Mockery::mock('League\\Tactician\\Handler\\MethodNameInflector\\MethodNameInflector');
 
         $this->middleware = new CommandHandlerMiddleware(
             $this->commandNameExtractor,
@@ -51,7 +49,7 @@ class CommandHandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $command = new CompleteTaskCommand();
 
-        $handler = Mockery::mock(ConcreteMethodsHandler::class);
+        $handler = Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler');
         $handler
             ->shouldReceive('handleCompleteTaskCommand')
             ->with($command)
@@ -65,13 +63,13 @@ class CommandHandlerMiddlewareTest extends \PHPUnit_Framework_TestCase
 
         $this->handlerLocator
             ->shouldReceive('getHandlerForCommand')
-            ->with(CompleteTaskCommand::class)
+            ->with('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand')
             ->andReturn($handler);
 
         $this->commandNameExtractor
             ->shouldReceive('extract')
             ->with($command)
-            ->andReturn(CompleteTaskCommand::class);
+            ->andReturn('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand');
 
         $this->assertEquals('a-return-value', $this->middleware->execute($command, $this->mockNext()));
     }

--- a/tests/Handler/Locator/InMemoryLocatorTest.php
+++ b/tests/Handler/Locator/InMemoryLocatorTest.php
@@ -23,31 +23,31 @@ class InMemoryLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $handler = new stdClass();
 
-        $this->inMemoryLocator->addHandler($handler, CompleteTaskCommand::class);
+        $this->inMemoryLocator->addHandler($handler, 'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand');
 
         $this->assertSame(
             $handler,
-            $this->inMemoryLocator->getHandlerForCommand(CompleteTaskCommand::class)
+            $this->inMemoryLocator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand')
         );
     }
 
     public function testConstructorAcceptsMapOfCommandClassesToHandlers()
     {
         $commandToHandlerMap = [
-            AddTaskCommand::class => new stdClass(),
-            CompleteTaskCommand::class => new stdClass()
+            'League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand' => new stdClass(),
+            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand' => new stdClass()
         ];
 
         $locator = new InMemoryLocator($commandToHandlerMap);
 
         $this->assertSame(
-            $commandToHandlerMap[AddTaskCommand::class],
-            $locator->getHandlerForCommand(AddTaskCommand::class)
+            $commandToHandlerMap['League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand'],
+            $locator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand')
         );
 
         $this->assertSame(
-            $commandToHandlerMap[CompleteTaskCommand::class],
-            $locator->getHandlerForCommand(CompleteTaskCommand::class)
+            $commandToHandlerMap['League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand'],
+            $locator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand')
         );
     }
 
@@ -56,6 +56,6 @@ class InMemoryLocatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testHandlerMissing()
     {
-        $this->inMemoryLocator->getHandlerForCommand(CompleteTaskCommand::class);
+        $this->inMemoryLocator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand');
     }
 }

--- a/tests/Handler/Locator/InMemoryLocatorTest.php
+++ b/tests/Handler/Locator/InMemoryLocatorTest.php
@@ -23,11 +23,16 @@ class InMemoryLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $handler = new stdClass();
 
-        $this->inMemoryLocator->addHandler($handler, 'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand');
+        $this->inMemoryLocator->addHandler(
+            $handler,
+            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand'
+        );
 
         $this->assertSame(
             $handler,
-            $this->inMemoryLocator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand')
+            $this->inMemoryLocator->getHandlerForCommand(
+                'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand'
+            )
         );
     }
 
@@ -56,6 +61,8 @@ class InMemoryLocatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testHandlerMissing()
     {
-        $this->inMemoryLocator->getHandlerForCommand('League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand');
+        $this->inMemoryLocator->getHandlerForCommand(
+            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand'
+        );
     }
 }

--- a/tests/Setup/QuickStartTest.php
+++ b/tests/Setup/QuickStartTest.php
@@ -4,7 +4,6 @@ namespace League\Tactician\Tests\Setup;
 
 use League\Tactician\Setup\QuickStart;
 use League\Tactician\Tests\Fixtures\Command\AddTaskCommand;
-use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
 use Mockery;
 
 class QuickStartTest extends \PHPUnit_Framework_TestCase
@@ -18,8 +17,10 @@ class QuickStartTest extends \PHPUnit_Framework_TestCase
     public function testCommandToHandlerMapIsProperlyConfigured()
     {
         $map = [
-            'League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand' => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
-            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand' => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
+            'League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand'
+                => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
+            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand'
+                => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
         ];
 
         $map['League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand']->shouldReceive('handle')->once();

--- a/tests/Setup/QuickStartTest.php
+++ b/tests/Setup/QuickStartTest.php
@@ -2,7 +2,6 @@
 
 namespace League\Tactician\Tests\Setup;
 
-use League\Tactician\CommandBus;
 use League\Tactician\Setup\QuickStart;
 use League\Tactician\Tests\Fixtures\Command\AddTaskCommand;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
@@ -13,18 +12,18 @@ class QuickStartTest extends \PHPUnit_Framework_TestCase
     public function testReturnsACommandBus()
     {
         $commandBus = QuickStart::create([]);
-        $this->assertInstanceOf(CommandBus::class, $commandBus);
+        $this->assertInstanceOf('League\\Tactician\\CommandBus', $commandBus);
     }
 
     public function testCommandToHandlerMapIsProperlyConfigured()
     {
         $map = [
-            AddTaskCommand::class => Mockery::mock(ConcreteMethodsHandler::class),
-            CompleteTaskCommand::class => Mockery::mock(ConcreteMethodsHandler::class),
+            'League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand' => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
+            'League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand' => Mockery::mock('League\\Tactician\\Tests\\Fixtures\\Handler\\ConcreteMethodsHandler'),
         ];
 
-        $map[AddTaskCommand::class]->shouldReceive('handle')->once();
-        $map[CompleteTaskCommand::class]->shouldReceive('handle')->never();
+        $map['League\\Tactician\\Tests\\Fixtures\\Command\\AddTaskCommand']->shouldReceive('handle')->once();
+        $map['League\\Tactician\\Tests\\Fixtures\\Command\\CompleteTaskCommand']->shouldReceive('handle')->never();
 
         $commandBus = QuickStart::create($map);
         $commandBus->handle(new AddTaskCommand());


### PR DESCRIPTION
Realized that main code doesn't use any features of 5.5+. 
Incompatibility is caused only by ::class magic constant usage in tests and examples.

So why not lower version according to real feature usage?

Unfortunately 5.4 is still widely set as a requirement: https://seld.be/notes/php-versions-stats-2016-1-edition
There are thousands of legacy projects (including mine) still using this version in production.
I know that 5.4 is an ancient thing now but this change could help other people with such real-life limitations to use the package without additional workarounds.