### PR TITLE
Introduce a PSR-11 handler locator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.3",
+        "psr/container": "^1.0",
         "squizlabs/php_codesniffer": "~2.3"
     },
     "autoload": {

--- a/src/Handler/Locator/ContainerLocator.php
+++ b/src/Handler/Locator/ContainerLocator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Tactician\Handler\Locator;
+
+use League\Tactician\Exception\MissingHandlerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Lazily loads Command Handlers from a PSR-11 container.
+ */
+class ContainerLocator implements HandlerLocator
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @param ContainerInterface $container A PSR-11 container holding command handlers
+     *                                      mapped by command names
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Gets the handler for a specified command.
+     *
+     * @param string $commandName
+     *
+     * @return object The command handler service
+     *
+     * @throws MissingHandlerException
+     */
+    public function getHandlerForCommand($commandName)
+    {
+        if (!$this->container->has($commandName)) {
+            throw MissingHandlerException::forCommand($commandName);
+        }
+
+        return $this->container->get($commandName);
+    }
+}

--- a/tests/Fixtures/Handler/Locator/SimpleContainer.php
+++ b/tests/Fixtures/Handler/Locator/SimpleContainer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\Tactician\Tests\Fixtures\Handler\Locator;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * A sample PSR-11 compliant container.
+ */
+class SimpleContainer implements ContainerInterface
+{
+    private $factories;
+
+    public function __construct(array $factories)
+    {
+        $this->factories = $factories;
+    }
+
+    public function get($id)
+    {
+        if (!isset($this->factories[$id])) {
+            throw new SimpleNotFoundException();
+        }
+
+        $factory = $this->factories[$id];
+
+        return $factory();
+    }
+
+    public function has($id)
+    {
+        return isset($this->factories[$id]);
+    }
+}

--- a/tests/Fixtures/Handler/Locator/SimpleNotFoundException.php
+++ b/tests/Fixtures/Handler/Locator/SimpleNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace League\Tactician\Tests\Fixtures\Handler\Locator;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+class SimpleNotFoundException extends \RuntimeException implements NotFoundExceptionInterface
+{
+}

--- a/tests/Fixtures/Handler/SimpleCommandHandler.php
+++ b/tests/Fixtures/Handler/SimpleCommandHandler.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Tactician\Tests\Fixtures\Handler;
+
+class SimpleCommandHandler
+{
+}

--- a/tests/Handler/Locator/ContainerLocatorTest.php
+++ b/tests/Handler/Locator/ContainerLocatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace League\Tactician\Tests\Handler\Locator;
+
+use League\Tactician\Handler\Locator\ContainerLocator;
+use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
+use League\Tactician\Tests\Fixtures\Handler\Locator\SimpleContainer;
+use League\Tactician\Tests\Fixtures\Handler\SimpleCommandHandler;
+
+class ContainerLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetHandlerForCommand()
+    {
+        $handlerFactories = [
+            CompleteTaskCommand::class => function () {
+                return new SimpleCommandHandler();
+            },
+        ];
+        $container = new SimpleContainer($handlerFactories);
+        $handlerLocator = new ContainerLocator($container);
+
+        $this->assertInstanceOf(
+            SimpleCommandHandler::class,
+            $handlerLocator->getHandlerForCommand(CompleteTaskCommand::class)
+        );
+    }
+
+    /**
+     * @expectedException \League\Tactician\Exception\MissingHandlerException
+     */
+    public function testGetHandlerForCommandThrowsOnUndefinedHandler()
+    {
+        (new ContainerLocator(new SimpleContainer([])))->getHandlerForCommand('undefined');
+    }
+}


### PR DESCRIPTION
First thanks for this library, I use it in pretty much all of my personal/enterprise projects.

This allows to lazy load handlers from any PSR-11 container.
In addition to being useful on its own, the final target of adding this locator is to make your `tactician-bundle` leverage the changes made in Symfony 3.3: we added the ability to lazy load services through explicit service locators, allowing to stop injecting the whole DI container (that is just bad design, it hides dependencies). See https://github.com/symfony/symfony/pull/21553, https://github.com/symfony/symfony/pull/21708 for references.

If accepted I would be glad to make your bundle uses this through the symfony dependency-injection component, replacing the current ContainerBasedHandlerLocator which is coupled to the symfony DIC. The main advantage for end users being that command handler services could be made private, leveraging the optimisations that the symfony DI performs on private services (better performances, better design).