### PR TITLE
Class Name Inflector

### DIFF
--- a/src/Handler/MethodNameInflector/ClassNameInflector.php
+++ b/src/Handler/MethodNameInflector/ClassNameInflector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace League\Tactician\Handler\MethodNameInflector;
+
+/**
+ * Assumes the method is only the last portion of the class name.
+ *
+ * Examples:
+ *  - \MyGlobalCommand    => $handler->myGlobalCommand()
+ *  - \My\App\CreateUser  => $handler->createUser()
+ */
+class ClassNameInflector implements MethodNameInflector
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function inflect($command, $commandHandler)
+    {
+        $commandName = get_class($command);
+
+        // If class name has a namespace separator, only take last portion
+        if (strpos($commandName, '\\') !== false) {
+            $commandName = substr($commandName, strrpos($commandName, '\\') + 1);
+        }
+
+        return strtolower($commandName[0]) . substr($commandName, 1);
+    }
+}

--- a/src/Handler/MethodNameInflector/HandleClassNameInflector.php
+++ b/src/Handler/MethodNameInflector/HandleClassNameInflector.php
@@ -9,20 +9,15 @@ namespace League\Tactician\Handler\MethodNameInflector;
  *  - \MyGlobalCommand              => $handler->handleMyGlobalCommand()
  *  - \My\App\TaskCompletedCommand  => $handler->handleTaskCompletedCommand()
  */
-class HandleClassNameInflector implements MethodNameInflector
+class HandleClassNameInflector extends ClassNameInflector
 {
     /**
      * {@inheritdoc}
      */
     public function inflect($command, $commandHandler)
     {
-        $commandName = get_class($command);
+        $commandName = parent::inflect($command, $commandHandler);
 
-        // If class name has a namespace separator, only take last portion
-        if (strpos($commandName, '\\') !== false) {
-            $commandName = substr($commandName, strrpos($commandName, '\\') + 1);
-        }
-
-        return 'handle' . $commandName;
+        return 'handle' . ucfirst($commandName);
     }
 }

--- a/tests/Handler/MethodNameInflector/ClassNameInflectorTest.php
+++ b/tests/Handler/MethodNameInflector/ClassNameInflectorTest.php
@@ -23,7 +23,7 @@ class ClassNameInflectorTest extends TestCase
     protected function setUp()
     {
         $this->inflector = new ClassNameInflector();
-        $this->handler = new ConcreteMethodsHandler();
+        $this->mockHandler = new ConcreteMethodsHandler();
     }
 
     public function testHandlesClassesWithoutNamespace()

--- a/tests/Handler/MethodNameInflector/ClassNameInflectorTest.php
+++ b/tests/Handler/MethodNameInflector/ClassNameInflectorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace League\Tactician\Tests\Handler\MethodNameInflector;
+
+use League\Tactician\Handler\MethodNameInflector\ClassNameInflector;
+use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
+use League\Tactician\Tests\Fixtures\Handler\ConcreteMethodsHandler;
+use CommandWithoutNamespace;
+use PHPUnit\Framework\TestCase;
+
+class ClassNameInflectorTest extends TestCase
+{
+    /**
+     * @var ClassNameInflector
+     */
+    private $inflector;
+
+    /**
+     * @var object
+     */
+    private $mockHandler;
+
+    protected function setUp()
+    {
+        $this->inflector = new ClassNameInflector();
+        $this->handler = new ConcreteMethodsHandler();
+    }
+
+    public function testHandlesClassesWithoutNamespace()
+    {
+        $command = new CommandWithoutNamespace();
+
+        $this->assertEquals(
+            'commandWithoutNamespace',
+            $this->inflector->inflect($command, $this->mockHandler)
+        );
+    }
+
+    public function testHandlesNamespacedClasses()
+    {
+        $command = new CompleteTaskCommand();
+
+        $this->assertEquals(
+            'completeTaskCommand',
+            $this->inflector->inflect($command, $this->mockHandler)
+        );
+    }
+}


### PR DESCRIPTION
I would like to have handler methods named without `handle` prefix. For example: `rentMovie` instead of `handleRentMovie`.

PR for docs: https://github.com/thephpleague/tactician/pull/119