### PR TITLE
Drop EOLed PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,18 @@ language: php
 dist: trusty
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
     - 7.2
+    - 7.3
+    - nightly
 
 matrix:
     include:
-        - php: 5.5
-          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+        -   php: 7.2
+            env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+
+jobs:
+    allow_failures:
+        -   php: nightly
 
 before_script:
     - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php":  ">=5.5"
+        "php":  "^7.2"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
I saw this on github

![image](https://user-images.githubusercontent.com/327717/49305652-1a837d80-f4d0-11e8-91cd-986606ad0eb3.png)

so I was like, yea, let's do this! Let's use modern standards!

[PHP 7.1 support is gone when you wake up this morning](http://php.net/supported-versions.php)

![image](https://user-images.githubusercontent.com/327717/49305695-3b4bd300-f4d0-11e8-8380-a4c159936663.png)

It's been great ride but it's time to say goodbye.

Let's use all those new features PHP has to offer and don't get stuck on PHP legacy versions. 
