### PR TITLE
Make marker interface extend throwable

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace League\Tactician;
 
+use Throwable;
+
 /**
  * Marker interface for all Tactician exceptions
  */
-interface Exception
+interface Exception extends Throwable
 {
 }


### PR DESCRIPTION
This makes sure the interface can only be used by exceptions/errors, and it means that tooling can understand that this can be 'caught.'