### PR TITLE
Remove unused imports

### DIFF
--- a/src/PHPStan/HandlerReturnTypeExtension.php
+++ b/src/PHPStan/HandlerReturnTypeExtension.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 namespace League\Tactician\PHPStan;
 
 use League\Tactician\CommandBus;
-use League\Tactician\Handler\Mapping\ClassName\ClassNameInflector;
 use League\Tactician\Handler\Mapping\CommandToHandlerMapping;
-use League\Tactician\Handler\Mapping\MethodName\MethodNameInflector;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;

--- a/tests/Handler/CommandHandlerMiddlewareTest.php
+++ b/tests/Handler/CommandHandlerMiddlewareTest.php
@@ -6,9 +6,7 @@ namespace League\Tactician\Tests\Handler;
 
 use League\Tactician\Handler\CanNotInvokeHandler;
 use League\Tactician\Handler\CommandHandlerMiddleware;
-use League\Tactician\Handler\Mapping\ClassName\ClassNameInflector;
 use League\Tactician\Handler\Mapping\CommandToHandlerMapping;
-use League\Tactician\Handler\Mapping\MethodName\MethodNameInflector;
 use League\Tactician\Tests\Fixtures\Command\CompleteTaskCommand;
 use League\Tactician\Tests\Fixtures\Handler\ConcreteMethodsHandler;
 use League\Tactician\Tests\Fixtures\Handler\DynamicMethodsHandler;


### PR DESCRIPTION
While browsing the repository I noticed some unused imports, which appear to be introduced in https://github.com/thephpleague/tactician/commit/25b977e8e07332c3d1e9f21796e284afbb4356c2. After quick inspection it seems they were also unused in a related test.