### PR TITLE
Use php 7.4 features

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -34,14 +34,10 @@ final class CommandBus
      */
     private function createExecutionChain(array $middlewareList): callable
     {
-        $lastCallable = static function (): void {
-            // the final callable is a no-op
-        };
+        $lastCallable = static fn () => null;
 
         while ($middleware = array_pop($middlewareList)) {
-            $lastCallable = static function ($command) use ($middleware, $lastCallable) {
-                return $middleware->execute($command, $lastCallable);
-            };
+            $lastCallable = static fn (object $command) => $middleware->execute($command, $lastCallable);
         }
 
         return $lastCallable;


### PR DESCRIPTION
Since we support php 7.4 as minimum version, we can use php 7.4 features like short function syntax