### PR TITLE
[DOCS] Changed repository links to reference the 1.x branch

### DIFF
--- a/tweaking-tactician.md
+++ b/tweaking-tactician.md
@@ -10,7 +10,7 @@ Tactician is really flexible, you can change almost anything about it. This page
 Along the way, we'll show you the important parts of Tactician so you can tweak them yourself.
 
 ## 1. Handler Method
-First, what method do you want to call on your Handlers when they receive a command? This is determined by the [`MethodNameInflector` classes](https://github.com/thephpleague/tactician/tree/master/src/Handler/MethodNameInflector). 
+First, what method do you want to call on your Handlers when they receive a command? This is determined by the [`MethodNameInflector` classes](https://github.com/thephpleague/tactician/tree/1.x/src/Handler/MethodNameInflector). 
 
 Assuming we have a Command class called `RentMovieCommand`, this table shows you what each inflector does: 
 
@@ -22,7 +22,7 @@ Handler Method             | Class to use                                | Notes
 `rentMovieCommand()`       | **`ClassNameInflector`**                    | Same as HandleClassName but without handle prefix
 `__invoke()`               | **`InvokeInflector`**                       | Good for invokable classes or closures.
 
-If you'd like to do something custom here, just implement the [`MethodNameInflector` interface](https://github.com/thephpleague/tactician/blob/master/src/Handler/MethodNameInflector/MethodNameInflector.php). All you need to do is return the string name of the method to call. This inflector will also receive the command and handler so you can use Reflection on them if you want.
+If you'd like to do something custom here, just implement the [`MethodNameInflector` interface](https://github.com/thephpleague/tactician/blob/1.x/src/Handler/MethodNameInflector/MethodNameInflector.php). All you need to do is return the string name of the method to call. This inflector will also receive the command and handler so you can use Reflection on them if you want.
 
 ## 2. Command Naming
 In order to load a Handler, we need to identify which Command we're dealing with. That's the job of the CommandNameExtractor classes: they accept an incoming command and then return a string name for it we can use to identify the command.
@@ -37,14 +37,14 @@ CommandNameExtractor    | Notes
 ## 3. Loading Your Handlers
 Now that we've got a Command's name, we can use it to load the actual Handler class. 
 
-The actual loading is done by the [`HandlerLocator` classes](https://github.com/thephpleague/tactician/tree/master/src/Handler/Locator). If you're using a Tactician framework module/bundle/provider, you should probably use the custom loader for that framework, but any locator will work.
+The actual loading is done by the [`HandlerLocator` classes](https://github.com/thephpleague/tactician/tree/1.x/src/Handler/Locator). If you're using a Tactician framework module/bundle/provider, you should probably use the custom loader for that framework, but any locator will work.
 
 The complete list of options are:
 
 Locator           | Notes
 ------------------|---------------------------------------------------
-[In Memory](https://github.com/thephpleague/tactician/blob/master/src/Handler/Locator/InMemoryLocator.php) | Maps Command Name to an existing Handler instance.
-[Callable](https://github.com/thephpleague/tactician/blob/master/src/Handler/Locator/CallableLocator.php) | Loads Commands from a callable (closure or ```[$object, 'method']```) 
+[In Memory](https://github.com/thephpleague/tactician/blob/1.x/src/Handler/Locator/InMemoryLocator.php) | Maps Command Name to an existing Handler instance.
+[Callable](https://github.com/thephpleague/tactician/blob/1.x/src/Handler/Locator/CallableLocator.php) | Loads Commands from a callable (closure or ```[$object, 'method']```) 
 [Container](https://github.com/thephpleague/tactician-container) | Maps Command Name to a container-interop Container instance.
 [Symfony Container](https://github.com/thephpleague/tactician-bundle) | Maps Command Name to Symfony service container tags
 
@@ -52,7 +52,7 @@ Configuring the Locator will vary depending on which Locator you use. Some will 
 
 If you'd like to wrap a DI container and there isn't an existing adapter, the easiest solution is to use the CallableLocator and pass it a callable like ```[$container, 'get']```. 
 
-You can also implement a custom Locators by implementing the [HandlerLocator interface](https://github.com/thephpleague/tactician/blob/master/src/Handler/Locator/HandlerLocator.php). This is just a single method that receives the Command Name as a string and returns the appropriate Handler.
+You can also implement a custom Locators by implementing the [HandlerLocator interface](https://github.com/thephpleague/tactician/blob/1.x/src/Handler/Locator/HandlerLocator.php). This is just a single method that receives the Command Name as a string and returns the appropriate Handler.
 
 ## 4. Creating the Command Bus
 Now that you've chosen a Locator, NameExtractor and MethodNameInflector, you need to pass them to the Command Bus for execution. In Tactician, there's one "core" command bus that you should always use: the CommandBus.
@@ -68,7 +68,7 @@ $commandBus = new CommandBus([]);
 
 To actually process the commands, we need to add Middleware.
 
-The most important piece of Middleware is the [CommandHandlerMiddleware](https://github.com/thephpleague/tactician/blob/master/src/Handler/CommandHandlerMiddleware.php). This class uses the Handler and MethodNameInflector we created above to find the right Handler and execute it.
+The most important piece of Middleware is the [CommandHandlerMiddleware](https://github.com/thephpleague/tactician/blob/1.x/src/Handler/CommandHandlerMiddleware.php). This class uses the Handler and MethodNameInflector we created above to find the right Handler and execute it.
 
 Pass that configured Middleware to your CommandBus and you're ready to rock.
 
@@ -112,6 +112,6 @@ You can create your own custom Middleware by implementing the [Middleware interf
 Tactician aims to ship with lots of useful decorators, you can find a complete list in the menu.
 
 ### And more
-If you've read this far down but you're still curious, take a look at the [examples directory on Github](https://github.com/thephpleague/tactician/tree/master/examples).
+If you've read this far down but you're still curious, take a look at the [examples directory on Github](https://github.com/thephpleague/tactician/tree/1.x/examples).
 
 Also, if you've implemented something custom for Tactician, from Inflectors to Middleware, please send us a pull request so we can share it with other Tactician users. We'd really appreciate it.


### PR DESCRIPTION
The documentation contains references to files that do not exist on the master branch anymore. Since this is the documentation for release 1.x, I think it makes sense to reference the 1.x files instead.