### PR TITLE
Hotfix: Catch Throwable instead of Exception in LockingMiddleware

### DIFF
--- a/src/Plugins/LockingMiddleware.php
+++ b/src/Plugins/LockingMiddleware.php
@@ -26,7 +26,7 @@ class LockingMiddleware implements Middleware
      * @param object   $command
      * @param callable $next
      *
-     * @throws \Exception
+     * @throws \Throwable
      *
      * @return mixed|void
      */
@@ -43,7 +43,7 @@ class LockingMiddleware implements Middleware
 
         try {
             $returnValue = $this->executeQueuedJobs();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->isExecuting = false;
             $this->queue = [];
             throw $e;

--- a/tests/Plugins/LockingMiddlewareTest.php
+++ b/tests/Plugins/LockingMiddlewareTest.php
@@ -111,6 +111,26 @@ class LockingMiddlewareTest extends TestCase
         );
     }
 
+    public function testErrorDoNotLeaveTheCommandBusLocked()
+    {
+        $next = function () {
+            throw new \Error();
+        };
+
+        try {
+            $this->lockingMiddleware->execute(new AddTaskCommand(), $next);
+        } catch (\Error $e) {
+        }
+
+        $next2 = function () use (&$executed) {
+            return true;
+        };
+        $this->assertTrue(
+            $this->lockingMiddleware->execute(new AddTaskCommand(), $next2),
+            'Second command was not executed'
+        );
+    }
+
     public function testExceptionsDoNotLeaveQueuedCommandsInTheBus()
     {
         $next = function () {


### PR DESCRIPTION
Hello :wave: 

If for instance a [ValueError](https://www.php.net/manual/en/class.valueerror.php) is thrown in a command handler using this locking middleware will execute second command.

I discovered this because new enum feature from PHP released on 8.1 throws a `ValueError` exception when value is not expected calling `from` method.

```php
enum Foo: string
{
    case BAR = 'bar';
}

Foo::from("not-bar"); // throws ValueError exception
```

Some playground with enums and exceptions: 
- https://3v4l.org/4AW7K

Then, `ValueError` extends [`Error`](https://www.php.net/manual/en/class.error.php) which implements `Throwable` but does **not** extends `Exception` so catch is not working as we expect.

I did the test with `Error` class since it is available from PHP 7.

On a side note, I realized this `LockingMiddleware` is not available in master branch but was not released 2.0 yet, so I patch `1.x` which I see has recent commits.